### PR TITLE
Update test matrix to exclude ubuntu-22.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         # ubuntu-22.04, macos-26, macos-13, macos-15, macos-15-intel
-        os: [ ubuntu-22.04, macos-15-intel, macos-26 ]
+        os: [ macos-15-intel, macos-26 ]
     runs-on: ${{ matrix.os }}
     permissions:
       actions: read


### PR DESCRIPTION
Removed 'ubuntu-22.04' from the test matrix.